### PR TITLE
Complete decompiled mash diary app compilation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,6 @@ plugins {
 android {
 	namespace "ru.mes.dnevnik"
     compileSdkVersion 34
-    buildToolsVersion "34.0.0"
 
     defaultConfig {
         applicationId 'ru.mes.dnevnik'
@@ -44,7 +43,7 @@ android {
     aaptOptions {
         ignoreAssetsPattern "!.svn:!.git:.*:!CVS:!thumbs.db:!picasa.ini:!*.scc:*~"
         noCompress 'tflite'
-        additionalParameters '--no-auto-version'
+        additionalParameters '--no-auto-version', '--keep-raw-values'
     }
     
     packagingOptions {


### PR DESCRIPTION
Remove `buildToolsVersion` and add `aapt2` flag to resolve resource linking errors.

This change addresses "expected enum but got (raw string)" errors in versioned resource files (`values-v*.xml`), common in decompiled applications, by instructing `aapt2` to keep raw string values. It also removes an outdated `buildToolsVersion` declaration to suppress a warning.

---
<a href="https://cursor.com/background-agent%3FbcId=bc-05f37116-2860-42a2-b4d7-1fc4a78ec6b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>