### PR TITLE
Complete decompiled mash diary app compilation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ android {
     aaptOptions {
         ignoreAssetsPattern "!.svn:!.git:.*:!CVS:!thumbs.db:!picasa.ini:!*.scc:*~"
         noCompress 'tflite'
-        additionalParameters '--no-auto-version', '--keep-raw-values'
+        additionalParameters '--no-auto-version', '--keep-raw-values', '--exclude-configs', 'v27,v29,v30'
     }
     
     packagingOptions {


### PR DESCRIPTION
Add `--exclude-configs v27,v29,v30` to aaptOptions to resolve resource linking errors.

This change addresses persistent "expected enum but got (raw string)" errors in versioned resource files (`values-v27/v29/v30.xml`) by instructing AAPT2 to exclude these problematic configurations during resource linking. This is a workaround for issues found in decompiled library resources.

---
<a href="https://cursor.com/background-agent%3FbcId=bc-05f37116-2860-42a2-b4d7-1fc4a78ec6b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>